### PR TITLE
Add empty line to fix inlined "Setup" heading

### DIFF
--- a/VotingTab.Rmd
+++ b/VotingTab.Rmd
@@ -11,6 +11,7 @@ positive and negative votes. **Hot Rob** has been declared the winner and I thin
 we all know why
 * Prom: The Musical and Super Mario Brothers tied for least positive interest,
 but Super Mario Brothers garnered substantially more negative votes.
+
 ## Setup
 
 <details><summary>Click here for setup code</summary>


### PR DESCRIPTION
This is showing up as inlined without it:
<img width="980" alt="Screen Shot 2021-01-04 at 5 27 25 PM" src="https://user-images.githubusercontent.com/5826405/103586031-4002c280-4eb2-11eb-98b4-d60a083eb07f.png">
